### PR TITLE
fix(readme): mark installed build deps as deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Compiling `asusctl` requires the Rust compiler and Cargo toolchain from [rustup.
 #### Arch Linux
 
 ```sh
-sudo pacman -S git cmake clang pkg-config libzip rust openssl
+sudo pacman -S --needed --asdeps git cmake clang pkg-config libzip rust openssl
 make
 sudo make install
 ```


### PR DESCRIPTION
Fixes: right now it installs the packages but doesn't mark as deps. It also reinstalls up-to-date packages.