### PR TITLE
fix(rog-aura): restore power states before keyboard mode

### DIFF
--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -339,15 +339,15 @@ impl CtrlTask for AuraZbus {
 impl Reloadable for AuraZbus {
     async fn reload(&mut self) -> Result<(), RogError> {
         self.0.fix_ally_power().await?;
-        debug!("reloading keyboard mode");
         let mut config = self.0.lock_config().await;
-        self.0.write_current_config_mode(&mut config).await?;
         debug!("reloading power states");
         self.0
             .set_power_states(&config)
             .await
             .map_err(|err| warn!("{err}"))
             .ok();
+        debug!("reloading keyboard mode");
+        self.0.write_current_config_mode(&mut config).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Description

Fixes an issue where the keyboard LED color/effect on some ASUS laptops is reset when asusd is restarted.

During Aura initialization/reload, the power states were being restored after the current keyboard lighting mode. On affected hardware, applying the power state resets the keyboard lighting, leaving the LEDs in the wrong state.

This changes the reload order so that the power states are restored first, followed by the current keyboard mode. This allows the configured keyboard lighting to be restored correctly after asusd starts or reloads.
Fixes # (issue)

Please note that AI was used to fix the issue

## Tested Hardware & Environment

- **ASUS Laptop Model: G712LW**
- **Linux Distribution: Fedora**
- **Kernel Version: 7.1.10-200.fc44.x86_64**

<!-- If this is a work in progress (WIP), please check the draft box and list the tasks below: -->
<!-- 
# TODO
- [ ] Task
-->

# Verification and testing:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [ ] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [ ] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [ ] Cranky with 0 warning (`cargo cranky`)
